### PR TITLE
ensure that columns in a merge operation can still be included in the…

### DIFF
--- a/src/FluentCommand.SqlServer/Merge/DataMergeGenerator.cs
+++ b/src/FluentCommand.SqlServer/Merge/DataMergeGenerator.cs
@@ -104,7 +104,7 @@ public static class DataMergeGenerator
     public static string BuildMerge(DataMergeDefinition mergeDefinition, IDataReader reader)
     {
         var mergeColumns = mergeDefinition.Columns
-            .Where(c => !c.IsIgnored)
+            .Where(c => !c.IsIgnored && (c.IsKey || c.CanInsert || c.CanUpdate))
             .ToList();
 
         var builder = StringBuilderCache.Acquire();


### PR DESCRIPTION
… output even if they're not included in the insert/update sections

This will allow us to set `CanUpdate` and `CanInsert` to false and still expect to see the column in the output section of the generated sql.